### PR TITLE
GitHub Deployment webhook

### DIFF
--- a/kapten/github.py
+++ b/kapten/github.py
@@ -1,0 +1,76 @@
+import hashlib
+import hmac
+import json
+from typing import Any, Dict, List, Tuple, Union
+
+from starlette.datastructures import Secret
+
+from .log import logger
+
+
+def validate_signature(
+    secret: Union[str, Secret], request_body: bytes, signature: str
+) -> bool:
+    """
+    See also:
+        https://developer.github.com/webhooks/#delivery-headers
+    for how GitHub creates the signature
+    """
+    if not signature:
+        logger.debug("No signature value")
+        return False
+
+    try:
+        digest = hmac.new(
+            key=bytes(str(secret), "utf-8"), msg=request_body, digestmod=hashlib.sha1,
+        )
+        return hmac.compare_digest("sha1={}".format(digest.hexdigest()), signature)
+    except (ValueError, TypeError) as e:
+        logger.error(e)
+        return False
+    except Exception as e:  # pragma: nocover
+        logger.critical(e)
+        return False
+
+
+def parse_webhook_payload(
+    payload: Dict[str, Any], tracked_repositories: List[str]
+) -> Tuple[str, str]:
+    # Validate payload structure
+    valid_structure = payload and all(
+        [
+            "deployment" in payload,
+            "statuses_url" in payload.get("deployment", {}),
+            "payload" in payload.get("deployment", {}),
+            "digest" in payload.get("deployment", {}).get("payload", {}),
+            "tag" in payload.get("deployment", {}).get("payload", {}),
+            "image" in payload.get("deployment", {}).get("payload", {}),
+            "repository" in payload,
+            "full_name" in payload.get("repository", {}),
+        ]
+    )
+    if not valid_structure:
+        raise ValueError("Invalid GitHub payload")
+
+    deployment_payload = json.loads(payload["deployment"]["payload"])
+    image = deployment_payload["image"]
+    if image not in tracked_repositories:
+        raise ValueError("No image value")
+
+    callback_url = payload["deployment"]["statuses_url"]
+    if not callback_url.startswith("https://api.github.com/repos/"):
+        raise ValueError("Invalid GitHub callback url: {}".format(callback_url))
+
+    tag = deployment_payload["tag"]
+    if not tag:
+        raise ValueError("No tag value")
+
+    # Format: <IMAGE>@<DIGEST> where DIGEST is prefixed with: 'sha256' expected
+    digest = deployment_payload["digest"]
+    if "@" not in digest:
+        raise ValueError("Invalid digest value: {}".format(digest))
+    digest = digest.split("@")[1]
+    if not digest.startswith("sha256:"):
+        raise ValueError("Invalid digest value: {}".format(digest))
+
+    return f"{image}:{tag}@{digest}", callback_url

--- a/kapten/server.py
+++ b/kapten/server.py
@@ -3,7 +3,7 @@ from starlette.config import Config
 from starlette.datastructures import Secret
 from starlette.responses import JSONResponse, Response
 
-from . import __version__, dockerhub
+from . import __version__, dockerhub, github
 from .exceptions import KaptenAPIError
 from .log import logger
 from .tool import Kapten
@@ -44,6 +44,57 @@ async def dockerhub_webhook(request):
         return Response(status_code=400)
 
     # Update all services matching this image
+    try:
+        updated_services = await app.state.client.update_services(image=image)
+    except KaptenAPIError as e:
+        logger.warning(e)
+        return Response(status_code=503)
+    except Exception as e:  # pragma: nocover
+        logger.error(e)
+        return Response(status_code=500)
+
+    if not updated_services:
+        logger.debug("No service(s) updated for image: %s", image)
+
+    return JSONResponse(
+        [
+            {"service": service.name, "image": service.image_with_digest}
+            for service in updated_services
+        ]
+    )
+
+
+@app.route("/webhook/github", methods=["POST"])
+async def github_webhook(request):
+    logger.info("Received GitHub webhook from: %s", request.client.host)
+
+    # Validate event type
+    event_type = request.headers.get("x-github-event") or ""
+    if event_type.lower() != "deployment":
+        logger.debug("Responding to unwanted GitHub event: {}".format(event_type))
+        return Response("Event not handled by Kapten", status_code=202)
+
+    # Validate signature
+    signature = request.headers.get("x-hub-signature") or ""
+    request_body = await request.body()  # NOTE: Comes as bytes
+    if not github.validate_signature(app.state.token, request_body, signature):
+        logger.critical("Invalid GitHub signature")
+        return Response(status_code=404)
+
+    payload = await request.json()
+    repositories = app.state.repositories
+    # Parse payload
+    try:
+        image, callback_url = github.parse_webhook_payload(payload, repositories)
+    except ValueError as e:
+        logger.critical(e)
+        return Response(status_code=404)
+
+    # TODO: Schedule update service
+    # TODO: Respond with success to webhook (GitHub only waits for 10 sec for response)
+    # TODO: Post deployment status "in_progress" to GitHub
+
+    # Update all services matching this deploy
     try:
         updated_services = await app.state.client.update_services(image=image)
     except KaptenAPIError as e:

--- a/kapten/tool.py
+++ b/kapten/tool.py
@@ -96,6 +96,7 @@ class Kapten:
 
         # Filter by given image
         if image:
+            # TODO: Filter with regex match instead of exact match
             services = list(filter(lambda s: s.image == image, services))
 
         return services
@@ -137,15 +138,19 @@ class Kapten:
 
         return new_service
 
-    async def update_services(self, image: Optional[str] = None) -> List[Service]:
+    async def update_services(self, image: str = "") -> List[Service]:
         updated_services = []
 
         # List services
+        image, _, digest = image.partition("@")
         services = await self.list_services(image=image)
 
-        # Fetch latest digests for service's images
-        images = list({service.image for service in services})
-        digests = await self.get_latest_digests(images)
+        if not digest:
+            # Fetch latest digests for service's images
+            images = list({service.image for service in services})
+            digests = await self.get_latest_digests(images)
+        else:
+            digests = {service.image: digest for service in services}
 
         # Deploy services
         results = await asyncio.gather(

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,11 +1,66 @@
-import asynctest
+import contextlib
+import re
+
+import httpx
+import respx
 
 from kapten import github
 
+from .testcases import KaptenTestCase
 
-class GitHubTestCase(asynctest.TestCase):
+
+class GitHubTestCase(KaptenTestCase):
+    @contextlib.contextmanager
+    def mock_github(
+        self,
+        repo_name="5monkeys/app",
+        deploy_id=123,
+        state="success",
+        environment="development",
+        description="Deployment finished successfully",
+        with_api_exception=False,
+    ):
+        respx.post(
+            re.compile(r"^https://api\.github\.com/repos/.*/deployments/.*/statuses$"),
+            status_code=httpx.codes.UNAUTHORIZED
+            if with_api_exception
+            else httpx.codes.OK,
+            content={},
+            alias="github",
+        )
+        payload = {
+            "url": f"https://api.github.com/repos/{repo_name}/deployments/{deploy_id}/statuses",
+            "state": state,
+            "environment": environment,
+            "description": description,
+        }
+        yield payload
+
     def test_validate_signature(self):
         secret = "secret"
         request_body = "body"  # Bytes expected; this should raise
         signature = "sha1=abc123"
         self.assertFalse(github.validate_signature(secret, request_body, signature))
+
+    async def test_callback(self):
+        with self.mock_github() as callback_kwargs:
+            result = await github.callback(**callback_kwargs)
+            self.assertTrue(result)
+            request_body = self.get_request_body("github")
+            self.assertEqual(request_body["state"], "success")
+            self.assertEqual(request_body["environment"], "development")
+            self.assertIn("description", request_body)
+            headers = self.get_request_headers("github")
+            self.assertEqual(
+                headers["Accept"], "application/vnd.github.flash-preview+json"
+            )
+
+    async def test_callback_invalid_state(self):
+        with self.mock_github(state="unknown") as callback_kwargs:
+            with self.assertRaises(ValueError):
+                await github.callback(**callback_kwargs)
+
+    async def test_callback_is_error(self):
+        with self.mock_github(with_api_exception=True) as callback_kwargs:
+            result = await github.callback(**callback_kwargs)
+            self.assertFalse(result)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,11 @@
+import asynctest
+
+from kapten import github
+
+
+class GitHubTestCase(asynctest.TestCase):
+    def test_validate_signature(self):
+        secret = "secret"
+        request_body = "body"  # Bytes expected; this should raise
+        signature = "sha1=abc123"
+        self.assertFalse(github.validate_signature(secret, request_body, signature))

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -165,6 +165,10 @@ class KaptenTestCase(asynctest.TestCase):
         calls = respx.aliases[alias].calls
         return json.loads(calls[call_number - 1][0].content.decode("utf-8"))
 
+    def get_request_headers(self, alias, call_number=1):
+        calls = respx.aliases[alias].calls
+        return calls[call_number - 1][0].headers
+
     @contextlib.contextmanager
     def mock_stdout(self):
         with mock.patch("sys.stdout", StringIO()) as stdout:


### PR DESCRIPTION
### _A few obstacles_:

GitHub expects a _response_ on webhooks within **[10 seconds](https://developer.github.com/v3/guides/best-practices-for-integrators/#favor-asynchronous-work-over-synchronous)**, hence we'll most likely want to, as quickly as possible, validate the webhook, schedule a service update asynchronously and respond back with 200 to GitHub.

Furthermore we'd want to update a captured GitHub deployment object through creating [deployment statuses](https://developer.github.com/v3/repos/deployments/#create-a-deployment-status) during and at the end of a triggered service update. This requires Kapten to be authenticated towards https://api.github.com with proper permissions for the repository that created the deployment.

- [ ] Update service(s) asynchronously after receiving webhook event `deployment` from GitHub
- [ ] Configure Kapten with authentication (token?) for given GitHub repository(ies?)
- [ ] Post deployment statuses to a GitHub deployment(`in_progress`, `error`, `success`, etc)