### PR TITLE
Fix invalid logging call

### DIFF
--- a/kapten/tool.py
+++ b/kapten/tool.py
@@ -47,7 +47,7 @@ class Kapten:
 
         nof_services = len(services)
         logger.info(
-            "Tracking {} service{}", nof_services, "s" if nof_services > 1 else ""
+            "Tracking %s service%s", nof_services, "s" if nof_services > 1 else ""
         )
 
         return nof_services

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -173,6 +173,16 @@ class CLICommandTestCase(KaptenTestCase):
                 self.cli_command(argv, with_healthcheck=True)
             self.assertEqual(cm.exception.code, 666)
 
+    def test_healthcheck_logging(self):
+        services = [("foo", "repo/foo:tag@sha256:0")]
+        argv = self.build_sys_args(services, "--check")
+
+        with self.mock_docker(services, api_version="1.39"):
+            self.cli_command(argv, with_healthcheck=True)
+            self.logger_mock.info.assert_has_calls(
+                [call("Tracking %s service%s", 1, "")], any_order=True
+            )
+
     def test_command_server_not_supported(self):
         services = [("foo", "repo/foo:tag@sha256:0")]
         argv = self.build_sys_args(


### PR DESCRIPTION
- '.format' string syntax not supported by logging module