### PR TITLE
Pin respx

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ def test(session):
         "pytest-asyncio",
         "pytest-cov",
         "asynctest",
-        "respx>=0.8.1",
+        "respx==0.8.1",
         "requests",  # needed by starlette test client
     )
     session.install("-e", ".[server]")


### PR DESCRIPTION
`repsx=>0.8.2` and up requires `httpx=>0.11.0` but Kapten requires `>=0.9.3,<0.9.4`.